### PR TITLE
fix: `ExtraConfig` must not have additional properties

### DIFF
--- a/pydantic_api/notion/models/objects/properties/database_property.py
+++ b/pydantic_api/notion/models/objects/properties/database_property.py
@@ -5,7 +5,7 @@ Reference: https://developers.notion.com/reference/property-schema-object
 from typing import List, Optional, Literal, Union, Annotated
 
 from uuid import UUID
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from pydantic_api.base import BaseModel
 from ..common import ColorLiteral
@@ -19,7 +19,8 @@ from .common import (
 
 
 class EmptyConfig(BaseModel):
-    pass
+    ...
+    model_config = ConfigDict(extra="forbid")
 
 
 class BaseDatabaseProperty(BaseModel):


### PR DESCRIPTION
Currently, if the API response changed and additional properties are returned with the `EmptyConfig` object, it would silently ignore them. This change ensures that Pydantic throws when/if that happens.

This produce a merge conflict with #2, so best to merge #2 first and then we can rebase this one.