### PR TITLE
fix: page property type

### DIFF
--- a/pydantic_api/notion/models/objects/page.py
+++ b/pydantic_api/notion/models/objects/page.py
@@ -6,7 +6,7 @@ from pydantic import Field
 
 from pydantic_api.base import BaseModel
 from .user import PartialUser
-from .properties import TitleProperty
+from .properties import PageProperty, TitleProperty
 from .common import IconObject, CoverObject
 from .parent import DatabaseParentObject, PageParentObject, WorkspaceParentObject
 
@@ -35,7 +35,7 @@ class Page(BaseModel):
     in_trash: bool
     icon: Optional[IconObject] = Field(None)
     cover: Optional[CoverObject] = Field(None)
-    properties: Dict[str, Any] = Field(default_factory=dict)
+    properties: Dict[str, PageProperty] = Field(default_factory=dict)
     parent: ParentOfPage
     url: str
     public_url: Optional[str] = Field(None)


### PR DESCRIPTION
This actually results in page properties not being deserialized correctly at the moment - each property in `Page.properties` is a `dict` instead of a `BaseModel` subtype.

Current workaround is:
```py
page_property_adapter = TypeAdapter(PageProperty)
...
for prop_raw in page.properties
    if prop_raw is None:
        continue
    prop: PageProperty = page_property_adapter.validate_python(prop_raw)
```
