### PR TITLE
feat: expose `BaseDatabaseProperty`

### DIFF
--- a/pydantic_api/notion/models/objects/properties/database_property.py
+++ b/pydantic_api/notion/models/objects/properties/database_property.py
@@ -377,4 +377,6 @@ __all__ = [
     "UniqueIdDatabaseProperty",
     # Union Type
     "DatabaseProperty",
+    # Base Type
+    "BaseDatabaseProperty",
 ]


### PR DESCRIPTION
Reason: I want to allow a user to create their own projection function based on `id` and `name` of each property. Easiest way is to make the signature:
```py
column_name_projection: Callable[[BaseDatabaseProperty], str] = lambda x: x,
```