### PR TITLE
feat: expose `SelectPropertyConfig` and `MultiSelectPropertyConfig`

### DIFF
--- a/pydantic_api/notion/models/objects/properties/database_property.py
+++ b/pydantic_api/notion/models/objects/properties/database_property.py
@@ -380,4 +380,7 @@ __all__ = [
     "DatabaseProperty",
     # Base Type
     "BaseDatabaseProperty",
+    # Some config objects
+    "SelectPropertyConfig",
+    "MultiSelectPropertyConfig",
 ]


### PR DESCRIPTION
When introspecting the two different select types, the config types are needed.

Example:
```py
    for p in all_properties:
        if p.type not in ["multi_select", "select"]:
            continue
        
        data: MultiSelectPropertyConfig | SelectPropertyConfig = getattr(p, p.type)
        if data is None:
            continue
        for option in data.options:
            # We now know that there is a `.options` which is of type `List[SelectOption]`
            ...
```