### PR TITLE
refactor: remove uuid

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -329,17 +329,7 @@ files = [
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
-[[package]]
-name = "uuid"
-version = "1.30"
-description = "UUID object and generation functions (Python 2.3 or higher)"
-optional = false
-python-versions = "*"
-files = [
-    {file = "uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f"},
-]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5a0a7e9dd8c6ca1db66792255c08980eca805e797a8337083c5b71f31bd5c50f"
+content-hash = "309a4a4edb68cc72a98105f4c05300a41a372ea0e2c32d2bd2adbc5d9d5c319e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 python = "^3.10"
 emoji = "^2.14.0"
 pydantic-api-models = "^0.0.2"
-uuid = "^1.30"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.15.0"


### PR DESCRIPTION
`uuid` is a built-in since 3.7 - the package that had been added is 19 years old: https://pypi.org/project/uuid/1.30/#history