### PR TITLE
Fix IconObject and CoverObject typing to allow UploadedFileObject

### DIFF
--- a/pydantic_api/notion/models/objects/common.py
+++ b/pydantic_api/notion/models/objects/common.py
@@ -40,13 +40,26 @@ class IconObjectFactory:
         return EmojiObject(emoji=emoji)
 
 
-CoverObject = ExternalFileObject
+CoverObject = Union[ExternalFileObject, UploadedFileObject]
 
 
 class CoverObjectFactory:
     @classmethod
     def from_external_file(cls, url: str):
         return ExternalFileObject.from_url(url=url)
+
+    @classmethod
+    def from_uploaded_file(
+        cls,
+        url: str,
+        expire_time: Optional[datetime] = None,
+        name: str | None = None,
+    ):
+        return UploadedFileObject.new(
+            url=url,
+            expire_time=expire_time,
+            name=name,
+        )
 
 
 ColorLiteral = Literal[

--- a/pydantic_api/notion/models/objects/common.py
+++ b/pydantic_api/notion/models/objects/common.py
@@ -1,11 +1,12 @@
 from pydantic import AnyUrl
-from typing import Union, Literal
+from datetime import datetime
+from typing import Union, Literal, Optional
 
 from .emoji import EmojiObject
-from .file import ExternalFileObject
+from .file import ExternalFileObject, UploadedFileObject
 
 
-IconObject = Union[ExternalFileObject, EmojiObject]
+IconObject = Union[UploadedFileObject, ExternalFileObject, EmojiObject]
 
 
 class IconObjectFactory:
@@ -13,6 +14,19 @@ class IconObjectFactory:
     def from_external_file(cls, url: str, name: str | None = None):
         return ExternalFileObject.new(
             url=url,
+            name=name,
+        )
+
+    @classmethod
+    def from_uploaded_file(
+        cls,
+        url: str,
+        expire_time: Optional[datetime] = None,
+        name: str | None = None,
+    ):
+        return UploadedFileObject.new(
+            url=url,
+            expire_time=expire_time,
             name=name,
         )
 


### PR DESCRIPTION
Notion docs for Page icon field state that it should only be an Emoji or an ExternalFile, but I have encountered Notion Pages in the wild with UploadedFile icons, which fail validation.

Same for Page cover field state: it should only be an ExternalFile, but I have Notion Pages which use an UploadedFile as a cover.