### PR TITLE
fix: allow deleted users

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1752507617,
+        "lastModified": 1758514534,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d26f9cf218d8617168d26f749e02a6d87ea4bc28",
+        "rev": "b162818c2748c34eca873482cf677820a8cddb61",
         "type": "github"
       },
       "original": {
@@ -55,10 +55,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
+        "lastModified": 1758108966,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {
@@ -89,10 +89,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750441195,
+        "lastModified": 1755783167,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "0ceffe312871b443929ff3006960d29b120dc627",
+        "rev": "4a880fb247d24fbca57269af672e8f78935b0328",
         "type": "github"
       },
       "original": {
@@ -110,10 +110,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1749760516,
+        "lastModified": 1755249745,
         "owner": "cachix",
         "repo": "nixpkgs-python",
-        "rev": "908dbb466af5955ea479ac95953333fd64387216",
+        "rev": "b6632af2db9f47c79dac8f4466388c7b1b6c3071",
         "type": "github"
       },
       "original": {

--- a/pydantic_api/notion/models/objects/properties/page_property.py
+++ b/pydantic_api/notion/models/objects/properties/page_property.py
@@ -223,7 +223,7 @@ class NumberProperty(BasePageProperty):
 # people: Refer to https://developers.notion.com/reference/page-property-values#people
 class PeopleProperty(BasePageProperty):
     type: Literal["people"] = "people"
-    people: List[UserObject]
+    people: List[UserObject | DeletedUserObject]
 
     @classmethod
     def new_person_users(

--- a/tests/test_user_object.py
+++ b/tests/test_user_object.py
@@ -1,5 +1,5 @@
 import uuid
-from pydantic_api.notion.models.objects.properties.page_property import CreatedByProperty
+from pydantic_api.notion.models.objects.properties.page_property import CreatedByProperty, PeopleProperty
 from pydantic_api.notion.models.objects.user import UserObject, DeletedUserObject
 
 
@@ -16,3 +16,44 @@ def test_userobject_accepts_deleteduser():
     assert isinstance(created_by.created_by, DeletedUserObject)
     assert created_by.created_by.object == "user"
     assert created_by.created_by.id == user_id
+
+
+def test_people_property_accepts_deleted_users():
+    """Test that PeopleProperty can contain DeletedUserObject items when users are deleted."""
+    deleted_user_id = uuid.uuid4()
+    active_user_id = uuid.uuid4()
+    
+    data = {
+        "type": "people",
+        "people": [
+            {
+                "object": "user",
+                "id": deleted_user_id,
+            },
+            {
+                "object": "user", 
+                "id": active_user_id,
+                "type": "person",
+                "person": {
+                    "email": "active@example.com"
+                },
+                "name": "Active User",
+                "avatar_url": None
+            }
+        ]
+    }
+    
+    people_property = PeopleProperty.model_validate(data)
+    assert len(people_property.people) == 2
+    
+    # First user should be parsed as DeletedUserObject (no type/person data)
+    assert isinstance(people_property.people[0], DeletedUserObject)
+    assert people_property.people[0].object == "user"
+    assert people_property.people[0].id == deleted_user_id
+    
+    # Second user should be parsed as PersonUserObject (has type/person data)
+    from pydantic_api.notion.models.objects.user import PersonUserObject
+    assert isinstance(people_property.people[1], PersonUserObject)
+    assert people_property.people[1].object == "user"
+    assert people_property.people[1].id == active_user_id
+    assert people_property.people[1].person.email == "active@example.com"


### PR DESCRIPTION
When a user is removed from a Workspace but still mentioned on a page, the API responds with a deleted user object.

references https://github.com/stevieflyer/pydantic-api-models-notion/pull/17